### PR TITLE
projects: remove spotlight sheen and tilt/hover effects

### DIFF
--- a/app/projects/_components/SkillsAndCases.tsx
+++ b/app/projects/_components/SkillsAndCases.tsx
@@ -118,7 +118,7 @@ export default function SkillsAndCases() {
         {visible.map((c, i) => (
           <article
             key={c.slug}
-            className={`group cq relative min-h-[360px] transform-gpu rounded-2xl bg-[linear-gradient(135deg,rgba(59,130,246,0.35),rgba(168,85,247,0.22),rgba(34,211,238,0.2))] p-[1px] shadow-[0_8px_28px_rgba(0,0,0,0.35)] ring-1 ring-white/5 transition-transform duration-300 [transform-style:preserve-3d] after:pointer-events-none after:absolute after:inset-0 after:rounded-2xl after:bg-[linear-gradient(120deg,rgba(255,255,255,0)_0%,rgba(255,255,255,0.14)_50%,rgba(255,255,255,0)_100%)] after:opacity-0 after:mix-blend-overlay after:transition-opacity after:duration-300 group-hover:after:opacity-100 focus-within:[transform:perspective(1000px)_rotateX(0.6deg)_rotateY(-0.6deg)] focus-within:after:opacity-100 hover:-translate-y-0.5 md:min-h-[430px] md:hover:[transform:perspective(1000px)_rotateX(0.6deg)_rotateY(-0.6deg)] ${!prefersReducedMotion ? 'animate-fade-in-up' : ''}`}
+            className={`group cq relative min-h-[360px] rounded-2xl bg-[linear-gradient(135deg,rgba(59,130,246,0.35),rgba(168,85,247,0.22),rgba(34,211,238,0.2))] p-[1px] shadow-[0_8px_28px_rgba(0,0,0,0.35)] ring-1 ring-white/5 md:min-h-[430px] ${!prefersReducedMotion ? 'animate-fade-in-up' : ''}`}
             style={{ animationDelay: !prefersReducedMotion ? `${80 * i}ms` : undefined }}
           >
             <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-white/5 bg-gray-950/70 backdrop-blur-md [@container(min-width:36rem)]:grid [@container(min-width:36rem)]:grid-cols-[1fr,1.5fr]">
@@ -128,7 +128,7 @@ export default function SkillsAndCases() {
                 width={c.image.width}
                 height={c.image.height}
                 style={{ aspectRatio: c.image.ratio }}
-                className="h-36 w-full transform-gpu object-cover transition-transform duration-500 ease-out [will-change:transform] md:h-44 md:group-hover:translate-y-[-2px] md:group-hover:scale-[1.03] [@container(min-width:28rem)]:h-44 [@container(min-width:36rem)]:h-full"
+                className="h-36 w-full object-cover md:h-44 [@container(min-width:28rem)]:h-44 [@container(min-width:36rem)]:h-full"
               />
               <div className="flex flex-1 flex-col gap-3 p-5 [@container(min-width:36rem)]:p-6">
                 <div className="flex items-center justify-between gap-4">


### PR DESCRIPTION
This PR removes the interactive spotlight sheen overlay and the tilt/hover lift on project cards, simplifying the visual interaction on the Projects page.\n\nChanges\n- Remove sheen overlay from project card container (previous after: gradient overlay on hover).\n- Remove 3D tilt/hover lift transforms and image hover translate/scale.\n- Keep overall card styling, borders, and layout intact.\n\nContext\n- We previously ensured build health by suppressing false-positive Biome lints for CSS View Transition named selectors and kept the prebuild script from auto-applying fixes (manual fixes preferred).\n\nVerification\n- pnpm build passes (checks + type-checks).\n- Projects page loads with simplified hover behavior and no tilt/lift.\n\nTest Plan\n- pnpm build\n- pnpm dev, then navigate to /projects and hover cards to confirm no sheen/tilt/lift.\n\n