### PR TITLE
Remove radial spotlight overlays on Projects and Work pages

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -6,10 +6,6 @@ import SkillsAndCases from './_components/SkillsAndCases';
 export default function ProjectsPage() {
   return (
     <section className="relative w-full overflow-hidden">
-      {/* Ambient background */}
-      <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute inset-x-0 top-0 h-[40vh] bg-[radial-gradient(40%_30%_at_50%_0%,rgba(59,130,246,0.20),transparent)] opacity-40" />
-      </div>
       <div className="cq container pt-48 pb-16 sm:pt-52">
         {/* Header */}
         <div className="animate-fade-in-up space-y-5">

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -5,7 +5,6 @@ export default function WorkPage() {
     <section className="relative w-full overflow-hidden">
       {/* Ambient background */}
       <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute inset-x-0 top-0 h-[36vh] bg-[radial-gradient(50%_35%_at_50%_0%,rgba(34,211,238,0.18),transparent)] opacity-40" />
         <div className="motion-safe-only scroll-element animate-spin-slow absolute top-1/2 left-1/2 h-[120vw] w-[120vw] -translate-x-1/2 -translate-y-1/2 rounded-full opacity-[0.08] blur-3xl [animation-duration:22s] [background:conic-gradient(from_0deg_at_50%_50%,rgba(168,85,247,0.45),rgba(59,130,246,0.35),rgba(34,211,238,0.30),rgba(168,85,247,0.45))]" />
       </div>
       <div className="cq container pt-48 pb-16 sm:pt-52">


### PR DESCRIPTION
This PR removes the page-level radial spotlight gradient overlays on:/projects – deletes the top radial gradient background to prevent the "half-sphere" look inside cards/work – removes the top radial gradient overlay; keeps the conic spinner intact\n\nNo other background systems changed (AmbientBackground remains).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Removed ambient radial-gradient background from the Projects page for a cleaner, distraction-free header area.
  - Removed ambient radial-gradient overlay from the Work page to streamline visuals and ensure a consistent look and feel.
  - Improves visual clarity while maintaining existing layout and interactions.
  - No changes to content, navigation, or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->