### PR TITLE
refactor: remove read case study buttons

### DIFF
--- a/app/projects/_components/SkillsAndCases.tsx
+++ b/app/projects/_components/SkillsAndCases.tsx
@@ -181,7 +181,6 @@ export default function SkillsAndCases() {
                 </p>
 
                 <div className="mt-auto flex flex-wrap gap-2">
-                  <ProjectLink href={`/projects/${c.slug}`}>Read case study</ProjectLink>
                   {c.links.map((l) => {
                     let icon: React.ReactNode = null;
                     switch (l.icon) {


### PR DESCRIPTION
## Summary of Changes
- Removed the 'Read case study' buttons from the projects page (`SkillsAndCases.tsx`).

## Checks Run
- `pnpm type-check`
- `pnpm check` (eslint + prettier)

## Notes
- No new environment variables added
- No migrations needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the "Read case study" link from project cards, keeping only the dynamic project links intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->