### PR TITLE
[codex] improve homepage scroll performance

### DIFF
--- a/app/(home)/animations/pill-shrink.ts
+++ b/app/(home)/animations/pill-shrink.ts
@@ -21,6 +21,7 @@ export type PillShrinkTimelineArgs = NavMeasurementHelpers & {
   overlay: HTMLDivElement | null;
   watermarkMask: HTMLDivElement | null;
   profile: HTMLDivElement;
+  isConstrainedExperience: boolean;
 };
 
 export type PillShrinkTimelineResult = {
@@ -56,6 +57,7 @@ export function createPillShrinkTimeline({
   overlay,
   watermarkMask,
   profile,
+  isConstrainedExperience,
   getTargetPillWidth,
   getTargetPillHeight,
   getNavRowYOffset,
@@ -69,6 +71,7 @@ export function createPillShrinkTimeline({
   let lastTargetOffset: { x: number; y: number } | null = null;
   const isSmallScreen =
     typeof window !== "undefined" && window.matchMedia("(max-width: 768px)").matches;
+  const shouldRealtimeAlign = !isSmallScreen && !isConstrainedExperience;
   const scrubSmoothing = isSmallScreen ? 0.9 : SCROLL_TIMING.SCRUB_SMOOTHING;
 
   const syncPillToNavRow = () => {
@@ -129,13 +132,13 @@ export function createPillShrinkTimeline({
         },
         invalidateOnRefresh: true,
         onUpdate: () => {
-          if (!isSmallScreen) {
+          if (shouldRealtimeAlign) {
             syncPillToNavRow();
           }
         },
         onRefresh: () => {
           lastTargetOffset = null;
-          if (!isSmallScreen) {
+          if (shouldRealtimeAlign) {
             syncPillToNavRow();
           }
         },
@@ -307,6 +310,7 @@ export function createPillShrinkTimeline({
       videoShrinkTimeline.scrollTrigger?.kill();
       videoShrinkTimeline.kill();
       pillSnapTween?.kill();
+      lastTargetOffset = null;
     },
   };
 }

--- a/app/(home)/animations/reduced-motion.ts
+++ b/app/(home)/animations/reduced-motion.ts
@@ -18,6 +18,7 @@ export type ReducedMotionArgs = {
   nameplate: HTMLDivElement | null;
   designation: HTMLDivElement | null;
   mobileHeroText: HTMLDivElement | null;
+  shouldLoadHeroVideo: boolean;
 };
 
 /**
@@ -40,6 +41,7 @@ export function applyReducedMotionState({
   nameplate,
   designation,
   mobileHeroText,
+  shouldLoadHeroVideo,
 }: ReducedMotionArgs): void {
   gsap.set(pill, {
     ...FINAL_PANEL_STATE,
@@ -49,18 +51,18 @@ export function applyReducedMotionState({
     boxShadow: PILL_SHRINK_BOX_SHADOW,
   });
   gsap.set(pillContent, { autoAlpha: 0 });
-  gsap.set(video, { autoAlpha: 1 });
+  gsap.set(video, { autoAlpha: shouldLoadHeroVideo ? 1 : 0 });
 
   if (overlay) {
-    gsap.set(overlay, { autoAlpha: OVERLAY_OPACITY.INITIAL });
+    gsap.set(overlay, { autoAlpha: shouldLoadHeroVideo ? OVERLAY_OPACITY.INITIAL : 0 });
   }
 
   if (watermarkMask) {
-    gsap.set(watermarkMask, { autoAlpha: 1 });
+    gsap.set(watermarkMask, { autoAlpha: shouldLoadHeroVideo ? 1 : 0 });
   }
 
   if (pillSkin) {
-    gsap.set(pillSkin, { autoAlpha: 0 });
+    gsap.set(pillSkin, { autoAlpha: shouldLoadHeroVideo ? 0 : 1 });
   }
 
   if (profile) {

--- a/app/(home)/components/Hero/Navigation.tsx
+++ b/app/(home)/components/Hero/Navigation.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Icon } from "@iconify/react";
 import type { CSSProperties } from "react";
 
 import { NavPill } from "@/components/navigation/NavPill";
+import { AppIcon } from "@/components/primitives/AppIcon";
 
 const HERO_NAV_PILL_WIDTH = "clamp(280px, var(--nav-row-w, 22vw), 520px)";
 const HERO_NAV_PILL_HEIGHT = "clamp(48px, var(--pill-h, 10vh), 72px)";
@@ -14,7 +14,7 @@ type NavItem = {
   href: string;
   ariaLabel: string;
   tooltip: string;
-  icon: string;
+  icon: "github" | "linkedin" | "projects" | "work";
   iconSize: number;
   vtTagName?: "projects" | "work";
   external?: boolean;
@@ -25,7 +25,7 @@ const NAV_ITEMS: NavItem[] = [
     href: "https://www.linkedin.com/in/jayvicsanantonio/",
     ariaLabel: "LinkedIn",
     tooltip: "LinkedIn",
-    icon: "mdi:linkedin",
+    icon: "linkedin",
     iconSize: 36,
     external: true,
   },
@@ -33,7 +33,7 @@ const NAV_ITEMS: NavItem[] = [
     href: "/projects",
     ariaLabel: "Projects",
     tooltip: "Projects",
-    icon: "mdi:application-brackets",
+    icon: "projects",
     iconSize: 32,
     vtTagName: "projects",
   },
@@ -41,7 +41,7 @@ const NAV_ITEMS: NavItem[] = [
     href: "/work",
     ariaLabel: "Work Experience",
     tooltip: "Work Experience",
-    icon: "mdi:timeline-text",
+    icon: "work",
     iconSize: 32,
     vtTagName: "work",
   },
@@ -49,7 +49,7 @@ const NAV_ITEMS: NavItem[] = [
     href: "https://github.com/jayvicsanantonio",
     ariaLabel: "GitHub",
     tooltip: "GitHub",
-    icon: "mdi:github",
+    icon: "github",
     iconSize: 36,
     external: true,
   },
@@ -73,7 +73,7 @@ export default function Navigation() {
                 key={item.ariaLabel}
                 href={item.href}
                 ariaLabel={item.ariaLabel}
-                icon={<Icon icon={item.icon} width={item.iconSize} height={item.iconSize} />}
+                icon={<AppIcon name={item.icon} width={item.iconSize} height={item.iconSize} />}
                 tooltip={item.tooltip}
                 collapsedPx={HERO_NAV_BUTTON_WIDTH}
                 heightPx={HERO_NAV_BUTTON_HEIGHT}
@@ -102,7 +102,7 @@ export default function Navigation() {
                 key={item.ariaLabel}
                 href={item.href}
                 ariaLabel={item.ariaLabel}
-                icon={<Icon icon={item.icon} width={item.iconSize} height={item.iconSize} />}
+                icon={<AppIcon name={item.icon} width={item.iconSize} height={item.iconSize} />}
                 tooltip={item.tooltip}
                 collapsedPx={HERO_NAV_BUTTON_WIDTH}
                 heightPx={HERO_NAV_BUTTON_HEIGHT}

--- a/app/(home)/components/Hero/Pill.tsx
+++ b/app/(home)/components/Hero/Pill.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 import { VIDEO_OVERLAY_BACKGROUND, VIDEO_WATERMARK_MASK } from "../config";
 import { useHeroContext } from "../../context/HeroContext";
 
@@ -9,7 +11,30 @@ export default function Pill() {
     videoWatermarkMaskRef,
     pillContentRef,
     pillSkinRef,
+    shouldLoadHeroVideo,
   } = useHeroContext();
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) {
+      return;
+    }
+
+    if (!shouldLoadHeroVideo) {
+      video.pause();
+      video.removeAttribute("src");
+      video.load();
+      return;
+    }
+
+    if (video.getAttribute("src") === "/matrix-horizontal.mp4") {
+      return;
+    }
+
+    video.setAttribute("src", "/matrix-horizontal.mp4");
+    video.load();
+  }, [shouldLoadHeroVideo, videoRef]);
+
   return (
     <div
       ref={pillRef}
@@ -26,9 +51,7 @@ export default function Pill() {
         aria-hidden
         tabIndex={-1}
         className="absolute inset-0 z-0 h-full w-full rounded-[inherit] object-cover opacity-0 transform-gpu [will-change:transform]"
-      >
-        <source src="/matrix-horizontal.mp4" type="video/mp4" />
-      </video>
+      />
       <div
         ref={pillSkinRef}
         className="pointer-events-none absolute inset-[1px] z-[1] rounded-[inherit] opacity-0"

--- a/app/(home)/components/Hero/Profile.tsx
+++ b/app/(home)/components/Hero/Profile.tsx
@@ -5,8 +5,8 @@ import Image from "next/image";
 import { PROFILE_BASE_Z_INDEX, PROFILE_DROP_SHADOW } from "../config";
 import { useHeroContext } from "../../context/HeroContext";
 
-export default function Profile({ prefersReducedMotion }: { prefersReducedMotion: boolean }) {
-  const { profileRef } = useHeroContext();
+export default function Profile() {
+  const { profileRef, prefersReducedMotion } = useHeroContext();
 
   return (
     <div

--- a/app/(home)/components/Hero/ScrollIndicator.tsx
+++ b/app/(home)/components/Hero/ScrollIndicator.tsx
@@ -1,63 +1,72 @@
 "use client";
 
-import { Icon } from "@iconify/react";
-import { useLayoutEffect, useRef } from "react";
+import { useGSAP } from "@gsap/react";
 import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
+import { useRef } from "react";
+import { AppIcon } from "@/components/primitives/AppIcon";
+import { useHeroContext } from "../../context/HeroContext";
+
+gsap.registerPlugin(useGSAP, ScrollTrigger);
 
 export default function ScrollIndicator() {
+  const { isConstrainedExperience, prefersReducedMotion } = useHeroContext();
   const containerRef = useRef<HTMLDivElement>(null);
   const arrowRef = useRef<HTMLDivElement>(null);
 
-  useLayoutEffect(() => {
-    const container = containerRef.current;
-    const arrow = arrowRef.current;
+  useGSAP(
+    () => {
+      const container = containerRef.current;
+      const arrow = arrowRef.current;
 
-    if (!container || !arrow) return;
+      if (!container || !arrow) {
+        return;
+      }
 
-    // Initial state: hidden and centered
-    gsap.set(container, { opacity: 0, y: 20, xPercent: -50 });
+      if (prefersReducedMotion) {
+        gsap.set(container, { autoAlpha: 0, xPercent: -50 });
+        return;
+      }
 
-    // Entrance animation
-    const tl = gsap.timeline({
-      delay: 2.5, // Wait for other hero animations
-    });
+      gsap.set(container, { autoAlpha: 0, y: 20, xPercent: -50 });
 
-    tl.to(container, {
-      opacity: 1,
-      y: 0,
-      duration: 1,
-      ease: "power2.out",
-    });
+      const entranceTween = gsap.to(container, {
+        autoAlpha: 1,
+        y: 0,
+        duration: 1,
+        delay: 2.5,
+        ease: "power2.out",
+      });
 
-    // Continuous bounce animation
-    gsap.to(arrow, {
-      y: 10,
-      duration: 1.5,
-      repeat: -1,
-      yoyo: true,
-      ease: "power1.inOut",
-    });
+      const bounceTween = isConstrainedExperience
+        ? null
+        : gsap.to(arrow, {
+            y: 10,
+            duration: 1.5,
+            repeat: -1,
+            yoyo: true,
+            ease: "power1.inOut",
+          });
 
-    // Exit on scroll
-    ScrollTrigger.create({
-      trigger: document.body,
-      start: "top top",
-      end: "100px top",
-      scrub: true,
-      onUpdate: (self) => {
-        gsap.to(container, {
-          opacity: 1 - self.progress,
-          overwrite: "auto",
-        });
-      },
-    });
+      const setOpacity = gsap.quickSetter(container, "opacity");
+      const fadeTrigger = ScrollTrigger.create({
+        trigger: document.documentElement,
+        start: "top top",
+        end: "100px top",
+        scrub: true,
+        onUpdate: (self) => {
+          setOpacity(1 - self.progress);
+        },
+      });
 
-    return () => {
-      tl.kill();
-      ScrollTrigger.getAll().forEach((t) => t.kill());
-    };
-  }, []);
+      return () => {
+        entranceTween.kill();
+        bounceTween?.kill();
+        fadeTrigger.kill();
+      };
+    },
+    { dependencies: [isConstrainedExperience, prefersReducedMotion], scope: containerRef },
+  );
 
   return (
     <div
@@ -65,7 +74,7 @@ export default function ScrollIndicator() {
       className="fixed bottom-8 left-1/2 z-50 flex flex-col items-center gap-2 pointer-events-none mix-blend-difference"
     >
       <div ref={arrowRef} className="text-white/80">
-        <Icon icon="mdi:chevron-down" width={48} height={48} />
+        <AppIcon name="chevron-down" width={48} height={48} />
       </div>
     </div>
   );

--- a/app/(home)/components/HomePageContent.tsx
+++ b/app/(home)/components/HomePageContent.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useLayoutEffect } from "react";
-import usePrefersReducedMotion from "@/hooks/usePrefersReducedMotion";
 import Profile from "./Hero/Profile";
 import Hero from "./Hero";
 import Skills from "./Skills";
@@ -12,7 +11,6 @@ import { ScrollTrigger } from "gsap/ScrollTrigger";
 
 function HomePageInner({ children }: { children?: React.ReactNode }) {
   const { smoothContentRef } = useHeroContext();
-  const prefersReducedMotion = usePrefersReducedMotion();
 
   return (
     <>
@@ -22,7 +20,7 @@ function HomePageInner({ children }: { children?: React.ReactNode }) {
         <Skills />
         <About />
       </div>
-      <Profile prefersReducedMotion={prefersReducedMotion} />
+      <Profile />
       <ScrollIndicator />
     </>
   );
@@ -30,42 +28,19 @@ function HomePageInner({ children }: { children?: React.ReactNode }) {
 
 export default function HomePageContent({ children }: { children?: React.ReactNode }) {
   useLayoutEffect(() => {
-    // 1. Disable browser's default scroll restoration
     if (window.history && window.history.scrollRestoration) {
       window.history.scrollRestoration = "manual";
     }
 
-    // 2. Clear GSAP scroll memory
     ScrollTrigger.clearScrollMemory();
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
 
-    // 3. NUCLEAR OPTION: Force scroll to top for a few frames
-    // This beats the browser's async scroll restoration
-    let frames = 0;
-    const forceScroll = () => {
-      if (frames < 30) {
-        // Run for ~500ms (30 frames at 60fps) to be absolutely sure
-        window.scrollTo(0, 0);
-        frames++;
-        requestAnimationFrame(forceScroll);
-      } else {
-        // Once we stop forcing scroll, refresh ScrollTrigger to ensure it sees the top position
-        ScrollTrigger.refresh();
-      }
-    };
-    forceScroll();
-
-    // 4. Ensure we scroll to top when leaving the page (for back button reliability)
-    const handleBeforeUnload = () => {
-      window.scrollTo(0, 0);
-      // Try to clear history state scroll position
-      if (window.history && window.history.replaceState) {
-        window.history.replaceState(null, "", window.location.href);
-      }
-    };
-    window.addEventListener("beforeunload", handleBeforeUnload);
+    const raf = requestAnimationFrame(() => {
+      ScrollTrigger.refresh();
+    });
 
     return () => {
-      window.removeEventListener("beforeunload", handleBeforeUnload);
+      cancelAnimationFrame(raf);
     };
   }, []);
 

--- a/app/(home)/context/HeroContext.tsx
+++ b/app/(home)/context/HeroContext.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { createContext, useContext, useRef, type ReactNode } from "react";
-import type { HeroAnimationRefs } from "../types";
+import type { HeroAnimationRefs, HeroContextValue } from "../types";
 import usePrefersReducedMotion from "@/hooks/usePrefersReducedMotion";
 import useHeroAnimations from "../hooks/use-hero-animations";
+import useHeroPerformanceMode from "../hooks/use-hero-performance-mode";
 
-const HeroContext = createContext<HeroAnimationRefs | null>(null);
+const HeroContext = createContext<HeroContextValue | null>(null);
 
 export function useHeroContext() {
   const context = useContext(HeroContext);
@@ -42,6 +43,7 @@ export function HeroProvider({ children }: { children: ReactNode }) {
   const mobileHeroTextRef = useRef<HTMLDivElement>(null);
 
   const prefersReducedMotion = usePrefersReducedMotion();
+  const { isConstrainedExperience, shouldLoadHeroVideo } = useHeroPerformanceMode();
 
   const refs: HeroAnimationRefs = {
     smoothWrapperRef,
@@ -70,10 +72,22 @@ export function HeroProvider({ children }: { children: ReactNode }) {
     mobileHeroTextRef,
   };
 
-  useHeroAnimations({ refs, prefersReducedMotion });
+  useHeroAnimations({
+    refs,
+    prefersReducedMotion,
+    isConstrainedExperience,
+    shouldLoadHeroVideo,
+  });
 
   return (
-    <HeroContext.Provider value={refs}>
+    <HeroContext.Provider
+      value={{
+        ...refs,
+        prefersReducedMotion,
+        shouldLoadHeroVideo,
+        isConstrainedExperience,
+      }}
+    >
       <main ref={smoothWrapperRef} id="smooth-wrapper" className="relative z-10 w-full text-white">
         {children}
       </main>

--- a/app/(home)/hooks/use-hero-animations.ts
+++ b/app/(home)/hooks/use-hero-animations.ts
@@ -8,7 +8,9 @@ import { useHeroScrollAnimation } from "./use-hero-scroll-animation";
 
 export type UseHeroAnimationArgs = {
   refs: HeroAnimationRefs;
+  isConstrainedExperience: boolean;
   prefersReducedMotion: boolean;
+  shouldLoadHeroVideo: boolean;
 };
 
 gsap.registerPlugin(useGSAP, ScrollTrigger);

--- a/app/(home)/hooks/use-hero-intro-animation.ts
+++ b/app/(home)/hooks/use-hero-intro-animation.ts
@@ -14,7 +14,9 @@ import { applyReducedMotionState } from "../animations/reduced-motion";
 
 export type UseHeroIntroAnimationArgs = {
   refs: HeroAnimationRefs;
+  isConstrainedExperience: boolean;
   prefersReducedMotion: boolean;
+  shouldLoadHeroVideo: boolean;
 };
 
 /**
@@ -51,7 +53,12 @@ export type UseHeroIntroAnimationArgs = {
  *   return <div ref={refs.containerRef}>...</div>;
  * }
  */
-export function useHeroIntroAnimation({ refs, prefersReducedMotion }: UseHeroIntroAnimationArgs) {
+export function useHeroIntroAnimation({
+  refs,
+  isConstrainedExperience,
+  prefersReducedMotion,
+  shouldLoadHeroVideo,
+}: UseHeroIntroAnimationArgs) {
   useGSAP(
     () => {
       // Extract required refs.
@@ -74,10 +81,11 @@ export function useHeroIntroAnimation({ refs, prefersReducedMotion }: UseHeroInt
       const nameplate = refs.nameplateRef.current;
       const designation = refs.designationRef.current;
       const mobileHeroText = refs.mobileHeroTextRef.current;
-      const isSmallScreen = typeof window !== "undefined" && window.matchMedia("(max-width: 1023px)").matches;
+      const isSmallScreen =
+        typeof window !== "undefined" && window.matchMedia("(max-width: 1023px)").matches;
 
       // Handle reduced motion preference.
-      if (prefersReducedMotion) {
+      if (prefersReducedMotion || isConstrainedExperience) {
         applyReducedMotionState({
           pill,
           pillContent,
@@ -90,11 +98,13 @@ export function useHeroIntroAnimation({ refs, prefersReducedMotion }: UseHeroInt
           nameplate,
           designation,
           mobileHeroText,
+          shouldLoadHeroVideo,
         });
-        // Start video playback immediately.
-        video.play().catch(() => {
-          // Silently handle autoplay restrictions.
-        });
+        if (shouldLoadHeroVideo) {
+          video.play().catch(() => {
+            // Silently handle autoplay restrictions.
+          });
+        }
         return;
       }
 
@@ -186,7 +196,7 @@ export function useHeroIntroAnimation({ refs, prefersReducedMotion }: UseHeroInt
         )
         // Add label for label reveal timing.
         .addLabel("labelReveal")
-        // Fade out pill background to reveal video.
+        // Fade out pill background to reveal the hero media.
         .to(
           pill,
           {
@@ -196,34 +206,46 @@ export function useHeroIntroAnimation({ refs, prefersReducedMotion }: UseHeroInt
           },
           "-=0.6",
         )
-        // Fade in video, overlay, and watermark mask.
-        .to(
-          [video, overlay, watermarkMask],
+        // Release scroll lock slightly before animation completes for smoother UX.
+        .add(releaseScrollLockIfNeeded, ">-0.25")
+        .addLabel("heroMediaReveal", "-=0.2");
+
+      if (shouldLoadHeroVideo) {
+        timeline
+          .to(
+            [video, overlay, watermarkMask],
+            {
+              autoAlpha: 1,
+              duration: INTRO_TIMING.VIDEO_FADE_DURATION,
+              ease: "power2.out",
+              onStart: () => {
+                video.play().catch(() => {
+                  // Silently handle autoplay restrictions.
+                });
+              },
+            },
+            "heroMediaReveal",
+          )
+          .to(
+            overlay,
+            {
+              autoAlpha: OVERLAY_OPACITY.INITIAL,
+              duration: INTRO_TIMING.OVERLAY_FADE_DURATION,
+              ease: "power1.out",
+            },
+            ">-0.1",
+          );
+      } else if (pillSkin) {
+        timeline.to(
+          pillSkin,
           {
             autoAlpha: 1,
             duration: INTRO_TIMING.VIDEO_FADE_DURATION,
             ease: "power2.out",
-            onStart: () => {
-              // Start video playback when it becomes visible.
-              video.play().catch(() => {
-                // Silently handle autoplay restrictions.
-              });
-            },
           },
-          "-=0.2",
-        )
-        // Release scroll lock slightly before animation completes for smoother UX.
-        .add(releaseScrollLockIfNeeded, ">-0.25")
-        // Adjust overlay opacity to final state.
-        .to(
-          overlay,
-          {
-            autoAlpha: OVERLAY_OPACITY.INITIAL,
-            duration: INTRO_TIMING.OVERLAY_FADE_DURATION,
-            ease: "power1.out",
-          },
-          ">-0.1",
+          "heroMediaReveal",
         );
+      }
 
       // Animate nameplate label if present.
       if (nameplate) {
@@ -282,6 +304,9 @@ export function useHeroIntroAnimation({ refs, prefersReducedMotion }: UseHeroInt
         timeline.kill();
       };
     },
-    { scope: refs.containerRef, dependencies: [prefersReducedMotion] },
+    {
+      scope: refs.containerRef,
+      dependencies: [isConstrainedExperience, prefersReducedMotion, shouldLoadHeroVideo],
+    },
   );
 }

--- a/app/(home)/hooks/use-hero-performance-mode.ts
+++ b/app/(home)/hooks/use-hero-performance-mode.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+
+type NavigatorConnection = {
+  effectiveType?: string;
+  saveData?: boolean;
+};
+
+type HeroPerformanceMode = {
+  isConstrainedExperience: boolean;
+  shouldLoadHeroVideo: boolean;
+};
+
+const SLOW_NETWORK_TYPES = new Set(["slow-2g", "2g", "3g"]);
+
+function readHeroPerformanceMode(): HeroPerformanceMode {
+  if (typeof navigator === "undefined") {
+    return {
+      isConstrainedExperience: false,
+      shouldLoadHeroVideo: true,
+    };
+  }
+
+  const nav = navigator as Navigator & {
+    connection?: NavigatorConnection;
+    mozConnection?: NavigatorConnection;
+    webkitConnection?: NavigatorConnection;
+    deviceMemory?: number;
+  };
+
+  const connection = nav.connection ?? nav.mozConnection ?? nav.webkitConnection;
+  const slowNetwork = connection?.effectiveType
+    ? SLOW_NETWORK_TYPES.has(connection.effectiveType)
+    : false;
+  const saveDataEnabled = connection?.saveData === true;
+  const lowMemory = typeof nav.deviceMemory === "number" && nav.deviceMemory <= 2;
+  const lowCpu = typeof nav.hardwareConcurrency === "number" && nav.hardwareConcurrency <= 4;
+  const isConstrainedExperience = slowNetwork || saveDataEnabled || lowMemory || lowCpu;
+
+  return {
+    isConstrainedExperience,
+    shouldLoadHeroVideo: !isConstrainedExperience,
+  };
+}
+
+export default function useHeroPerformanceMode(): HeroPerformanceMode {
+  const [mode] = useState(readHeroPerformanceMode);
+  return mode;
+}

--- a/app/(home)/hooks/use-hero-scroll-animation.ts
+++ b/app/(home)/hooks/use-hero-scroll-animation.ts
@@ -13,12 +13,16 @@ import { killTimeline } from "../animations/cleanup";
 
 export type UseHeroScrollAnimationArgs = {
   refs: HeroAnimationRefs;
+  isConstrainedExperience: boolean;
   prefersReducedMotion: boolean;
+  shouldLoadHeroVideo: boolean;
 };
 
 export function useHeroScrollAnimation({
   refs,
+  isConstrainedExperience,
   prefersReducedMotion,
+  shouldLoadHeroVideo,
 }: UseHeroScrollAnimationArgs): void {
   useGSAP(
     () => {
@@ -64,6 +68,20 @@ export function useHeroScrollAnimation({
         if (coverBody) {
           gsap.set(coverBody, { yPercent: 0 });
         }
+        if (!shouldLoadHeroVideo) {
+          if (video) {
+            gsap.set(video, { autoAlpha: 0 });
+          }
+          if (overlay) {
+            gsap.set(overlay, { autoAlpha: 0 });
+          }
+          if (watermarkMask) {
+            gsap.set(watermarkMask, { autoAlpha: 0 });
+          }
+          if (pillSkin) {
+            gsap.set(pillSkin, { autoAlpha: 1 });
+          }
+        }
         return () => {
           cleanupFns.forEach((cleanup) => cleanup());
         };
@@ -94,6 +112,7 @@ export function useHeroScrollAnimation({
         overlay,
         watermarkMask,
         profile,
+        isConstrainedExperience,
         getTargetPillWidth: navMeasurements.getTargetPillWidth,
         getTargetPillHeight: navMeasurements.getTargetPillHeight,
         getNavRowYOffset: navMeasurements.getNavRowYOffset,
@@ -141,6 +160,6 @@ export function useHeroScrollAnimation({
         cleanupFns.forEach((cleanup) => cleanup());
       };
     },
-    { dependencies: [prefersReducedMotion] },
+    { dependencies: [isConstrainedExperience, prefersReducedMotion, shouldLoadHeroVideo] },
   );
 }

--- a/app/(home)/types.ts
+++ b/app/(home)/types.ts
@@ -27,6 +27,12 @@ export type HeroAnimationRefs = {
   mobileHeroTextRef: MutableRefObject<HTMLDivElement | null>;
 };
 
+export type HeroContextValue = HeroAnimationRefs & {
+  isConstrainedExperience: boolean;
+  prefersReducedMotion: boolean;
+  shouldLoadHeroVideo: boolean;
+};
+
 export type MarqueeRowConfig = {
   items: string[];
   duration?: number;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -129,7 +129,6 @@ export default function RootLayout({
   return (
     <html lang="en" data-scroll-behavior="smooth">
       <head>
-        <link rel="preconnect" href="https://api.iconify.design" />
         <link rel="preconnect" href="https://va.vercel-scripts.com" />
       </head>
       <Body

--- a/app/projects/_components/SkillsAndCases.tsx
+++ b/app/projects/_components/SkillsAndCases.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Icon } from "@iconify/react";
 import Image from "next/image";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import React from "react";
@@ -9,6 +8,7 @@ import { PROJECTS } from "@/app/projects/projects.data";
 import usePrefersReducedMotion from "@/hooks/usePrefersReducedMotion";
 
 import { CARD_INNER_BASE, CARD_OUTER_BASE } from "@/components/styles/card-styles";
+import { AppIcon } from "@/components/primitives/AppIcon";
 import ProjectLink from "./ProjectLink";
 
 const SKILL_FILTERS = [
@@ -185,15 +185,15 @@ export default function SkillsAndCases() {
                     let icon: React.ReactNode = null;
                     switch (l.icon) {
                       case "github":
-                        icon = <Icon icon="mdi:github" width={18} height={18} />;
+                        icon = <AppIcon name="github" width={18} height={18} />;
                         break;
                       case "watch":
-                        icon = <Icon icon="mdi:play" width={16} height={16} />;
+                        icon = <AppIcon name="play" width={16} height={16} />;
                         break;
                       case "marketplace":
                       case "external":
                       case "view":
-                        icon = <Icon icon="mdi:open-in-new" width={16} height={16} />;
+                        icon = <AppIcon name="external" width={16} height={16} />;
                         break;
                       default:
                         icon = null;

--- a/app/work/_components/WorkTimeline.tsx
+++ b/app/work/_components/WorkTimeline.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { Icon } from "@iconify/react";
 import { useGSAP } from "@gsap/react";
 import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import { useRef } from "react";
 
 import { Badge } from "@/components/primitives/Badge";
+import { AppIcon } from "@/components/primitives/AppIcon";
 import { CARD_INNER_BASE, CARD_OUTER_BASE } from "@/components/styles/card-styles";
 import usePrefersReducedMotion from "@/hooks/usePrefersReducedMotion";
 
@@ -389,8 +389,8 @@ export default function WorkTimeline() {
                       <ul className="mt-4 space-y-3 text-[0.95rem]/relaxed sm:text-[0.98rem]/relaxed [@container(min-width:34rem)]:space-y-4">
                         {item.bullets.map((b) => (
                           <li key={b} className="flex gap-2 break-words text-gray-300/90">
-                            <Icon
-                              icon="mdi:check"
+                            <AppIcon
+                              name="check"
                               width={18}
                               height={18}
                               className="mt-0.5 shrink-0 text-cyan-300/80"

--- a/components/layout/ScrollProgressBar.tsx
+++ b/components/layout/ScrollProgressBar.tsx
@@ -10,8 +10,8 @@ export default function ScrollProgressBar({ progress }: ScrollProgressBarProps) 
   return (
     <div aria-hidden="true" className="fixed right-0 top-0 bottom-0 z-[999] w-2 bg-white/10">
       <div
-        className="absolute top-0 left-0 right-0 origin-top bg-gradient-to-b from-cyan-400/80 via-cyan-300/70 to-cyan-500/90 shadow-[0_0_10px_rgba(34,211,238,0.35)]"
-        style={{ height: `${clampedProgress * 100}%` }}
+        className="absolute inset-0 origin-top bg-gradient-to-b from-cyan-400/80 via-cyan-300/70 to-cyan-500/90 shadow-[0_0_10px_rgba(34,211,238,0.35)] [will-change:transform]"
+        style={{ transform: `scaleY(${clampedProgress})` }}
       />
     </div>
   );

--- a/components/navigation/GlassHeaderBubble.tsx
+++ b/components/navigation/GlassHeaderBubble.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Icon } from "@iconify/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import { NavPill } from "@/components/navigation/NavPill";
+import { AppIcon } from "@/components/primitives/AppIcon";
 export type GlassHeaderBubbleProps = {
   label: string;
   vtClassName?: string; // e.g., vt-tag-projects, vt-tag-work
@@ -45,8 +45,8 @@ export default function GlassHeaderBubble({
               href="https://www.linkedin.com/in/jayvicsanantonio/"
               ariaLabel="LinkedIn"
               icon={
-                <Icon
-                  icon="mdi:linkedin"
+                <AppIcon
+                  name="linkedin"
                   className="h-[clamp(24px,6vw,36px)] w-[clamp(24px,6vw,36px)]"
                   aria-hidden="true"
                 />
@@ -65,8 +65,8 @@ export default function GlassHeaderBubble({
               href="/projects"
               ariaLabel="Projects"
               icon={
-                <Icon
-                  icon="mdi:application-brackets"
+                <AppIcon
+                  name="projects"
                   className="h-[clamp(24px,6vw,36px)] w-[clamp(24px,6vw,36px)] font-bold"
                   aria-hidden="true"
                 />
@@ -89,8 +89,8 @@ export default function GlassHeaderBubble({
               href="/work"
               ariaLabel="Work"
               icon={
-                <Icon
-                  icon="mdi:timeline-text"
+                <AppIcon
+                  name="work"
                   className="h-[clamp(24px,6vw,36px)] w-[clamp(24px,6vw,36px)]"
                   aria-hidden="true"
                 />
@@ -113,8 +113,8 @@ export default function GlassHeaderBubble({
               href="https://github.com/jayvicsanantonio"
               ariaLabel="GitHub"
               icon={
-                <Icon
-                  icon="mdi:github"
+                <AppIcon
+                  name="github"
                   className="h-[clamp(24px,6vw,36px)] w-[clamp(24px,6vw,36px)]"
                   aria-hidden="true"
                 />

--- a/components/navigation/NavPill.tsx
+++ b/components/navigation/NavPill.tsx
@@ -19,6 +19,7 @@ export type NavPillProps = {
   tooltip?: string; // Tooltip text when non-active
   tooltipPlacement?: "above" | "below"; // Default: 'above'
   className?: string;
+  prefetch?: boolean;
 };
 
 export function NavPill({
@@ -36,11 +37,13 @@ export function NavPill({
   tooltip,
   tooltipPlacement = "above",
   className,
+  prefetch,
 }: NavPillProps) {
   // View-transition tag (optional)
   const vtClass = vtTagName ? `vt-tag-${vtTagName}` : "";
 
   const linkProps = external ? { target: "_blank", rel: "noopener noreferrer" as const } : {};
+  const prefetchProps = external ? {} : { prefetch: prefetch ?? false };
 
   return (
     <fieldset
@@ -78,6 +81,7 @@ export function NavPill({
         }}
         aria-current={active ? "page" : undefined}
         {...linkProps}
+        {...prefetchProps}
       >
         <span className="inline-flex items-center gap-2">
           <span

--- a/components/primitives/AppIcon.tsx
+++ b/components/primitives/AppIcon.tsx
@@ -1,0 +1,107 @@
+import type { SVGProps } from "react";
+
+type AppIconName =
+  | "chevron-down"
+  | "check"
+  | "external"
+  | "github"
+  | "linkedin"
+  | "play"
+  | "projects"
+  | "work";
+
+type AppIconProps = SVGProps<SVGSVGElement> & {
+  name: AppIconName;
+};
+
+const strokeProps = {
+  fill: "none",
+  stroke: "currentColor",
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+  strokeWidth: 1.75,
+};
+
+export function AppIcon({ name, className, ...props }: AppIconProps) {
+  switch (name) {
+    case "linkedin":
+      return (
+        <svg
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          className={className}
+          fill="currentColor"
+          {...props}
+        >
+          <circle cx="4" cy="4" r="2" />
+          <path d="M2 9h4v13H2z" />
+          <path d="M10 9h4v2.1A4.9 4.9 0 0 1 18.2 9C21 9 22 10.8 22 14.2V22h-4v-7c0-1.7-.6-2.8-2.1-2.8-1.1 0-1.8.8-2.1 1.5-.1.3-.1.8-.1 1.2V22h-4z" />
+        </svg>
+      );
+    case "github":
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" className={className} {...props}>
+          <path
+            {...strokeProps}
+            d="M15 22v-4a4.8 4.8 0 0 0-1-3.2c3.3-.4 6.8-1.6 6.8-7.2a5.6 5.6 0 0 0-1.5-3.9A5.2 5.2 0 0 0 19.2 1S17.7.7 15 2.5a13.2 13.2 0 0 0-6 0C6.3.7 4.8 1 4.8 1a5.2 5.2 0 0 0-.1 2.5 5.6 5.6 0 0 0-1.5 3.9c0 5.6 3.5 6.8 6.8 7.2a4.8 4.8 0 0 0-1 3.2v4"
+          />
+          <path {...strokeProps} d="M9 18c-4.5 2-5-2-7-2" />
+        </svg>
+      );
+    case "projects":
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" className={className} {...props}>
+          <path {...strokeProps} d="m8 4-5 8 5 8" />
+          <path {...strokeProps} d="m16 4 5 8-5 8" />
+          <path {...strokeProps} d="m14.5 4-5 16" />
+        </svg>
+      );
+    case "work":
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" className={className} {...props}>
+          <circle cx="7" cy="6" r="1.5" fill="currentColor" />
+          <circle cx="7" cy="12" r="1.5" fill="currentColor" />
+          <circle cx="7" cy="18" r="1.5" fill="currentColor" />
+          <path {...strokeProps} d="M10 6h9" />
+          <path {...strokeProps} d="M10 12h9" />
+          <path {...strokeProps} d="M10 18h9" />
+          <path {...strokeProps} d="M7 7.5v3" />
+          <path {...strokeProps} d="M7 13.5v3" />
+        </svg>
+      );
+    case "chevron-down":
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" className={className} {...props}>
+          <path {...strokeProps} d="m6 9 6 6 6-6" />
+        </svg>
+      );
+    case "play":
+      return (
+        <svg
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          className={className}
+          fill="currentColor"
+          {...props}
+        >
+          <path d="m8 5 11 7-11 7z" />
+        </svg>
+      );
+    case "external":
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" className={className} {...props}>
+          <path {...strokeProps} d="M7 17 17 7" />
+          <path {...strokeProps} d="M9 7h8v8" />
+          <path {...strokeProps} d="M17 13v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h4" />
+        </svg>
+      );
+    case "check":
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" className={className} {...props}>
+          <path {...strokeProps} d="m5 12 5 5L20 7" />
+        </svg>
+      );
+    default:
+      return null;
+  }
+}

--- a/hooks/usePrefersReducedMotion.ts
+++ b/hooks/usePrefersReducedMotion.ts
@@ -3,7 +3,11 @@ import { useEffect, useState } from "react";
 const QUERY = "(prefers-reduced-motion: no-preference)";
 
 const getInitialState = () => {
-  return false;
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return !window.matchMedia(QUERY).matches;
 };
 
 export default function usePrefersReducedMotion() {

--- a/hooks/useScrollProgress.ts
+++ b/hooks/useScrollProgress.ts
@@ -8,26 +8,32 @@ export function useScrollProgress(): number {
   useEffect(() => {
     let raf = 0;
 
-    const sample = () => {
+    const updateProgress = () => {
       const doc = document.documentElement;
       const max = Math.max(1, doc.scrollHeight - doc.clientHeight);
-      const p = Math.min(1, Math.max(0, doc.scrollTop / max));
-      setProgress(p);
-      raf = requestAnimationFrame(sample);
+      setProgress(Math.min(1, Math.max(0, doc.scrollTop / max)));
     };
 
-    sample();
+    const scheduleUpdate = () => {
+      if (raf !== 0) {
+        return;
+      }
 
-    const onResize = () => {
-      cancelAnimationFrame(raf);
-      raf = requestAnimationFrame(sample);
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        updateProgress();
+      });
     };
 
-    window.addEventListener("resize", onResize);
+    updateProgress();
+
+    window.addEventListener("scroll", scheduleUpdate, { passive: true });
+    window.addEventListener("resize", scheduleUpdate);
 
     return () => {
       cancelAnimationFrame(raf);
-      window.removeEventListener("resize", onResize);
+      window.removeEventListener("scroll", scheduleUpdate);
+      window.removeEventListener("resize", scheduleUpdate);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- optimize homepage scroll handling by removing the multi-frame scroll reset and replacing the scroll progress loop with scroll-driven updates
- add constrained-device/network handling so slower clients skip the hero video and long intro animation
- replace homepage Iconify usage with local SVG icons and disable nav prefetch to reduce first-visit network work

## Why
The homepage had avoidable main-thread work during scroll, extra speculative network traffic, and a heavy hero path that was not adapting well to slower devices or connections.

## Impact
- smoother scroll behavior on the index page
- better first-visit behavior on slow devices and save-data / slower-network clients
- fewer unnecessary requests on initial load

## Validation
- `pnpm type-check`
- `pnpm check`
- `pnpm build`
- Lighthouse desktop: 100 performance, 0.6s LCP, 0ms TBT, 0 CLS
- Lighthouse mobile: 95 performance, 3.0s LCP, 20ms TBT, 0 CLS
