### PR TITLE
refactor: reduce hero intro animation timing durations for faster sequence execution

### DIFF
--- a/app/(home)/components/config.ts
+++ b/app/(home)/components/config.ts
@@ -40,9 +40,9 @@ export const CFG = {
  * Timing values for the hero intro animation sequence.
  */
 export const INTRO_TIMING = {
-  DELAY: 1,
-  PILL_EXPAND_DURATION: 2,
-  PILL_ROUND_DURATION: 0.8,
+  DELAY: 0.2,
+  PILL_EXPAND_DURATION: 1.2,
+  PILL_ROUND_DURATION: 0.5,
   CONTENT_FADE_DURATION: 0.45,
   PROFILE_FADE_DURATION: 0.6,
   VIDEO_FADE_DURATION: 0.8,


### PR DESCRIPTION
The GSAP hero animations were intentionally holding a 1-second delay and a 2-second initial stretch duration. I've updated app/(home)/components/config.ts to reduce those parameters so that the animation runs snappier, delivering a fully constructed hero area significantly quicker.

